### PR TITLE
Update common.py

### DIFF
--- a/project_name/project_name/settings/common.py
+++ b/project_name/project_name/settings/common.py
@@ -164,6 +164,7 @@ LOGGING = {
 
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = False
+COMPRESS_CSS_HASHING_METHOD = 'content'
 COMPRESS_PRECOMPILERS = (
     ('text/less', 'lessc {infile} {outfile}'),
 )


### PR DESCRIPTION
the hash generated from compressor depends on the contents of files, making easier to compare if two compressed versions are from the same uncompressed files.
